### PR TITLE
Add CTAs

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-    "gitbook": "2.0.1",
+    "gitbook": "2.x.x",
     "plugins": ["edit-link"],
     "pluginsConfig": {
         "edit-link": {

--- a/en/README.md
+++ b/en/README.md
@@ -1,3 +1,8 @@
+<div class="cta-banner">
+  <a class="cta-banner-pdf" href="#">Read PDF<i class="fa fa-file-pdf-o"></i></a>
+  <a class="cta-banner-update" href="#">Receive Updates<i class="fa fa-bell-o"></i></a>
+</div>
+
 Incident Response for Android and iOS
 =======
 

--- a/en/styles/pdf.css
+++ b/en/styles/pdf.css
@@ -94,11 +94,11 @@ a:active:after {
 	font-weight: normal;
 }
 
-/*
 .pdf-header:after {
-
+  border-bottom: 1px solid gray;
+  color: #CCCCCC;
 }
-
+/*
 .pdf-footer {
 
 }
@@ -107,4 +107,20 @@ a:active:after {
 #endnotes ~ blockquote sup {
   position: relative;
   top: 5px;
+}
+
+#footnotes ~ blockquote sup {
+  position: relative;
+  top: 5px;
+}
+
+/* Do not display temp CTAs in md files */
+.cta-banner .cta-banner-pdf,
+.cta-banner .cta-banner-update {
+  display: none;
+}
+
+.fa-bell-o,
+.fa-file-pdf-o {
+  display: none;
 }

--- a/en/styles/website.css
+++ b/en/styles/website.css
@@ -46,6 +46,11 @@ h4 {
 
 /* Links */
 
+/* The edit page plugin cuts off almost all of the title so it's best to hide rn */
+.book .book-header h1 a {
+  display: none;
+}
+
 a {
   text-decoration: none !important;
 }
@@ -180,3 +185,28 @@ a {
 .fa-check:before {
   display: none;
 }
+
+/* Temp & wonky CTAs, custom plugin required. Don't forget to display: none in PDF */
+.cta-banner .cta-banner-pdf,
+.cta-banner .cta-banner-update {
+  text-align: center;
+  color: #CCCCCC !important;
+  font-weight: 700;
+  font-style: italic;
+}
+
+.cta-banner .cta-banner-pdf:hover,
+.cta-banner .cta-banner-update:hover {
+  color: gray !important;
+}
+
+.cta-banner .cta-banner-pdf {
+  padding-left: 0;
+  margin-right: 30px;
+}
+
+.fa-bell-o,
+.fa-file-pdf-o {
+  padding-left: 10px;
+}
+/* End CTAs */


### PR DESCRIPTION
- Adds the "Edit This Page" plugin
- Adds temporary CTAs to get PDF and sign up for updates. The current solutions adds HTML to markdown, so it will only show up on pages where it has been added directly at the top of the markdown file. The best solution here for future iterations is a custom plugin to add these to the main header (cannot edit the template directly without creating a theme or plugin). 
- Misc styling with site and PDF

_Still need to add the actual url to these "sub-header" CTAs tho_

<img width="1273" alt="screen shot 2016-02-18 at 4 53 13 pm" src="https://cloud.githubusercontent.com/assets/5723303/13160831/039c9b44-d668-11e5-960c-ae73d0aacb9b.png">
